### PR TITLE
Update rubocop.yml

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -30,3 +30,6 @@ Metrics/MethodLength:
 
 Style/ClassAndModuleChildren:
   Enabled: false
+  
+Style/StringLiterals:
+  Enabled: false


### PR DESCRIPTION
Аргументы за отключение:
1. Не надо лишний раз думать, будет ли в строке интерполяция
2. Если понадобилось вставить интерполяцию, не надо менять кавычки

PS. Строки без интерполяции не дают преимущества в скорости.