### PR TITLE
Update rubocop.yml

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -42,4 +42,7 @@ Lint/RescueException:
   
 Style/SingleLineBlockParams:
   Enabled: false
+  
+Style/Lambda:
+  Enabled: false
 


### PR DESCRIPTION
Разрешить использование `lambda {|x| x + 1 }`, а не только уродский `-> (x) { x + 1 }`