### PR TITLE
Запрещаем использовать короткие однобуквенные имена переменных в блоках

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -40,14 +40,17 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Naming/BlockParameterName:
+  MinNameLength: 3
+
 Style/ClassAndModuleChildren:
   Enabled: false
-  
+
 Style/StringLiterals:
   Enabled: false
-  
+
 Lint/RescueException:
   Enabled: false
-  
+
 Style/SingleLineBlockParams:
   Enabled: false


### PR DESCRIPTION
В Ruby не принято экономить на строках и символах. Мы - за семантичный понятный код.

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/BlockParameterName

примеры из доки рубокопа:

```ruby
# bad
baz { |a, b, c| do_stuff(a, b, c) }

# good
bar do |thud, fred|
  thud + fred
end

foo { |speed, distance| speed * distance }

baz { |age, height, gender| do_stuff(age, height, gender) }
```

Можно проголосовать с помощью 👍 и 👎 
