### PR TITLE
Временно удаялем коп Style/DocumentDynamicEvalDefinition

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -60,9 +60,6 @@ Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false
 
-Style/DocumentDynamicEvalDefinition:
-  Enabled: false
-
 Style/ClassAndModuleChildren:
   Enabled: false
 


### PR DESCRIPTION
Его нет в более старых версиях рубокопа, и пронто в 1С падает