### PR TITLE
CS-598 do not impose predicate methods for == comparisons

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -89,3 +89,6 @@ Style/StringLiterals:
 
 Style/SingleLineBlockParams:
   Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false


### PR DESCRIPTION
Do not force to replace `if x == 0` with `if x.zero?` (and so on).
https://www.rubydoc.info/gems/rubocop/0.57.2/RuboCop/Cop/Style/NumericPredicate