### PR TITLE
PT-675 allow aligned and unaligned hash values' listings

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -28,6 +28,11 @@ Layout/LineLength:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Layout/HashAlignment:
+  EnforcedHashRocketStyle:
+    - key
+    - table
+
 Metrics/AbcSize:
   Enabled: false
 


### PR DESCRIPTION
Разрешить оба варианта написания хэш-массивов, т.к. половина кода использует один, половина -- другой:
```
{
  :foo => bar,
  :ba => baz
}
```
и
```
{
  :foo => bar,
  :ba  => baz
}
```
https://www.rubydoc.info/gems/rubocop/0.83.0/RuboCop/Cop/Layout/HashAlignment